### PR TITLE
revitalize kungfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A FusePy based in memory filesystem
 Requirements:
 
 	FusePy - https://github.com/terencehonles/fusepy
-	Python 2.7 is known to work. 
+	Python 3.6 is known to work. 
 	Other Python versions may work
 	
 Inspiration:

--- a/mem.py
+++ b/mem.py
@@ -5,8 +5,6 @@ import os
 from fuse import FUSE, FuseOSError, Operations, LoggingMixIn
 
 class Property(dict):
-    """ Default Properties of a file/directory object"""
-
     def __init__(self, st_mode=493, st_nlink=0, st_size=0, st_ctime=0, st_mtime=0, st_atime=0, st_gid=0, st_uid=0, st_blocks=0):
         self.st_mode = st_mode
         self.st_nlink = st_nlink
@@ -18,26 +16,19 @@ class Property(dict):
         self.st_uid = os.getuid()
         self.st_blocks = st_blocks
 
-
 class Directory(object):
-    """ A directory object"""
-
     def __init__(self, files, directories, properties):
         self.files = files
         self.directories = directories
         self.properties = properties
 
-
 class File(object):
-    """ A file object"""
-
     def __init__(self, data, properties):
         self.data = data
         self.properties = properties
 
 
 class Memory(LoggingMixIn, Operations):
-    """Example memory filesystem. Supports only one level of files."""
 
     def __unicode__(self):
         return str(self)
@@ -171,13 +162,13 @@ class Memory(LoggingMixIn, Operations):
         targetdirobj = self.get_dir(targetdir)
         now = time.time()
         targetdirobj.files[targetname] = File(data=source, properties=Property(
-            st_mode=stat.S_IFLNK, st_nlink=1, st_size=len(source), st_ctime=now, st_mtime=now, st_atime=now, st_blocks=len(source)//512))
+            st_mode=stat.S_IFLNK, st_nlink=1, st_size=len(source), st_ctime=now, st_mtime=now, st_atime=now, st_blocks=len(source) // 512))
 
     def truncate(self, path, length, fh=None):
         st = self.get_file(path)
         st.data = st.data[:length]
         st.properties.st_size = length
-        st.properties.st_blocks = length//512
+        st.properties.st_blocks = length // 512
 
     def unlink(self, path):
         dirname = '/'.join(path.split('/')[:-1])
@@ -196,7 +187,7 @@ class Memory(LoggingMixIn, Operations):
         st = self.get_file(path)
         st.data[offset:] = data
         st.properties.st_size = len(st.data)
-        st.properties.st_blocks = len(st.data)//512
+        st.properties.st_blocks = len(st.data) // 512
         return len(data)
 
     def get_file(self, path):
@@ -224,9 +215,10 @@ class Memory(LoggingMixIn, Operations):
                 location = location.directories[dirpath]
             else:
                 return None
-
         return location
 
+
 if __name__ == '__main__':
-   import sys
-   fuse = FUSE(Memory(), sys.argv[1], foreground=True, debug=True)
+    import sys
+    if sys.argv[0] == 'mem.py':
+        fuse = FUSE(Memory(), sys.argv[1], foreground=True, debug=True)

--- a/mem.py
+++ b/mem.py
@@ -1,31 +1,26 @@
-from collections import defaultdict
-from errno import ENOENT
-from stat import S_IFDIR, S_IFLNK, S_IFREG
-from sys import argv, exit
-from time import time
+import errno
+import stat
+import time
+import os
 from fuse import FUSE, FuseOSError, Operations, LoggingMixIn
-
 
 class Property(dict):
     """ Default Properties of a file/directory object"""
 
-    def __init__(self, st_mode=493, st_nlink=0, st_size=0, st_ctime='', st_mtime='', st_atime='', st_gid=0, st_uid=0):
+    def __init__(self, st_mode=493, st_nlink=0, st_size=0, st_ctime=0, st_mtime=0, st_atime=0, st_gid=0, st_uid=0, st_blocks=0):
         self.st_mode = st_mode
         self.st_nlink = st_nlink
         self.st_size = st_size
         self.st_ctime = st_ctime
         self.st_mtime = st_mtime
         self.st_atime = st_atime
-        self.st_gid = st_gid
-        self.st_uid = st_uid
+        self.st_gid = os.getgid()
+        self.st_uid = os.getuid()
+        self.st_blocks = st_blocks
 
 
 class Directory(object):
     """ A directory object"""
-
-    files = {}
-    directories = {}
-    properties = Property()
 
     def __init__(self, files, directories, properties):
         self.files = files
@@ -35,9 +30,6 @@ class Directory(object):
 
 class File(object):
     """ A file object"""
-
-    data = b''
-    properties = Property()
 
     def __init__(self, data, properties):
         self.data = data
@@ -53,23 +45,23 @@ class Memory(LoggingMixIn, Operations):
     def __init__(self):
         self.filesystem = {}
         self.fd = 0
-        now = time()
+        now = time.time()
         self.filesystem['/'] = Directory(files={}, directories={}, properties=Property(
-            st_mode=S_IFDIR | 493, st_nlink=2, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time(), st_gid=0, st_uid=0))
+            st_mode=stat.S_IFDIR | 493, st_nlink=2, st_size=0, st_ctime=now, st_mtime=now, st_atime=now, st_gid=os.getgid(), st_uid=os.getuid()))
 
     def chmod(self, path, mode):
-        item = self.getFile(path)
+        item = self.get_file(path)
         if not item:
-            item = self.getDir(path)
+            item = self.get_dir(path)
         if item:
             item.properties.st_mode &= 258048
             item.properties.st_mode |= mode
         return 0
 
     def chown(self, path, uid, gid):
-        item = self.getFile(path)
+        item = self.get_file(path)
         if not item:
-            item = self.getDir(path)
+            item = self.get_dir(path)
         if item:
             item.properties.st_uid = uid
             item.properties.st_gid = gid
@@ -78,34 +70,35 @@ class Memory(LoggingMixIn, Operations):
     def create(self, path, mode):
         filename = path.split('/')[-1]
         dirname = '/'.join(path.split('/')[:-1])
-        dirobj = self.getDir(dirname)
-        dirobj.files[filename] = File(data=b'', properties=Property(
-            st_mode=S_IFREG | mode, st_nlink=1, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time()))
+        dirobj = self.get_dir(dirname)
+        now = time.time()
+        dirobj.files[filename] = File(data=bytearray(), properties=Property(
+            st_mode=stat.S_IFREG | mode, st_nlink=1, st_size=0, st_ctime=now, st_mtime=now, st_atime=now))
         self.fd += 1
         return self.fd
 
     def getattr(self, path, fh=None):
-        st = self.getFile(path)
+        st = self.get_file(path)
         if not st:
-            st = self.getDir(path)
+            st = self.get_dir(path)
         if not st:
-            raise FuseOSError(ENOENT)
+            raise FuseOSError(errno.ENOENT)
         return st.properties.__dict__
 
     def getxattr(self, path, name, position=0):
-        st = self.getFile(path)
+        st = self.get_file(path)
         if not st:
-            st = self.getDir(path)
+            st = self.get_dir(path)
         attrs = st.properties.get('attrs', {})
         try:
             return attrs[name]
         except KeyError:
-            return ''
+            return b''
 
     def listxattr(self, path):
-        st = self.getFile(path)
+        st = self.get_file(path)
         if not st:
-            st = self.getDir(path)
+            st = self.get_dir(path)
         attrs = st.properties.get('attrs', {})
         return list(attrs.keys())
 
@@ -113,9 +106,10 @@ class Memory(LoggingMixIn, Operations):
         path = path.rstrip('/')
         newdir = path.split('/')[-1]
         dirname = '/'.join(path.split('/')[:-1])
-        dirobj = self.getDir(dirname)
+        dirobj = self.get_dir(dirname)
+        now = time.time()
         dirobj.directories[newdir] = Directory(files={}, directories={}, properties=Property(
-            st_mode=S_IFDIR | mode, st_nlink=2, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time()))
+            st_mode=stat.S_IFDIR | mode, st_nlink=2, st_size=0, st_ctime=now, st_mtime=now, st_atime=now))
         dirobj.properties.st_nlink += 1
 
     def open(self, path, flags):
@@ -123,21 +117,21 @@ class Memory(LoggingMixIn, Operations):
         return self.fd
 
     def read(self, path, size, offset, fh):
-        fileobj = self.getFile(path)
-        return fileobj.data[offset:(offset + size)]
+        fileobj = self.get_file(path)
+        return bytes(fileobj.data[offset:(offset + size)])
 
     def readdir(self, path, fh):
-        st = self.getDir(path)
+        st = self.get_dir(path)
         return ['.', '..'] + [x for x in st.files] + [x for x in st.directories]
 
     def readlink(self, path):
-        st = self.getFile(path)
+        st = self.get_file(path)
         return st.data
 
     def removexattr(self, path, name):
-        st = self.getFile(path)
+        st = self.get_file(path)
         if not st:
-            st = self.getDir(path)
+            st = self.get_dir(path)
         attrs = st.properties.get('attrs', {})
         try:
             del attrs[name]
@@ -148,23 +142,23 @@ class Memory(LoggingMixIn, Operations):
         oldname = old.split('/')[-1]
         newname = new.split('/')[-1]
         parentname = '/'.join(old.split('/')[:-1])
-        parentobj = self.getDir(parentname)
-        if self.getFile(old):
+        parentobj = self.get_dir(parentname)
+        if self.get_file(old):
             parentobj.files[newname] = parentobj.files.pop(oldname)
-        elif self.getDir(old):
+        elif self.get_dir(old):
             parentobj.directories[newname] = parentobj.directories.pop(oldname)
 
     def rmdir(self, path):
         parentname = '/'.join(path.split('/')[:-1])
-        parentobj = self.getDir(parentname)
+        parentobj = self.get_dir(parentname)
         dirname = path.split('/')[-1]
         parentobj.directories.pop(dirname)
         parentobj.properties.st_nlink -= 1
 
     def setxattr(self, path, name, value, options, position=0):
-        st = self.getFile(path)
+        st = self.get_file(path)
         if not st:
-            st = self.getDir(path)
+            st = self.get_dir(path)
         attrs = st.setdefault('attrs', {})
         attrs[name] = value
 
@@ -174,48 +168,50 @@ class Memory(LoggingMixIn, Operations):
     def symlink(self, target, source):
         targetname = target.split('/')[-1]
         targetdir = '/'.join(target.split('/')[:-1])
-        targetdirobj = self.getDir(targetdir)
-
+        targetdirobj = self.get_dir(targetdir)
+        now = time.time()
         targetdirobj.files[targetname] = File(data=source, properties=Property(
-            st_mode=S_IFLNK, st_nlink=1, st_size=len(source), st_ctime=time(), st_mtime=time(), st_atime=time()))
+            st_mode=stat.S_IFLNK, st_nlink=1, st_size=len(source), st_ctime=now, st_mtime=now, st_atime=now, st_blocks=len(source)//512))
 
     def truncate(self, path, length, fh=None):
-        st = self.getFile(path)
+        st = self.get_file(path)
         st.data = st.data[:length]
         st.properties.st_size = length
+        st.properties.st_blocks = length//512
 
     def unlink(self, path):
         dirname = '/'.join(path.split('/')[:-1])
         filename = path.split('/')[-1]
-        st = self.getDir(dirname)
+        st = self.get_dir(dirname)
         st.files.pop(filename)
 
     def utimens(self, path, times=None):
-        now = time()
+        now = time.time()
         (atime, mtime,) = times if times else (now, now)
-        st = self.getFile(path)
+        st = self.get_file(path)
         st.properties.st_atime = atime
         st.properties.st_mtime = mtime
 
     def write(self, path, data, offset, fh):
-        st = self.getFile(path)
-        st.data = st.data[:offset] + data
+        st = self.get_file(path)
+        st.data[offset:] = data
         st.properties.st_size = len(st.data)
+        st.properties.st_blocks = len(st.data)//512
         return len(data)
 
-    def getFile(self, path):
+    def get_file(self, path):
         if path[-1] == '/':
             return None
         else:
             patharray = path.split('/')
             filename = patharray.pop()
             dirname = '/'.join(path.split('/')[:-1])
-            location = self.getDir(dirname)
+            location = self.get_dir(dirname)
             if location and filename in location.files:
                 return location.files[filename]
             return None
 
-    def getDir(self, path):
+    def get_dir(self, path):
         path = path.rstrip('/')
         patharray = path.split('/')
         if len(patharray) <= 1:
@@ -231,6 +227,6 @@ class Memory(LoggingMixIn, Operations):
 
         return location
 
-
 if __name__ == '__main__':
-    fuse = FUSE(Memory(), argv[1], foreground=True)#, debug=True)
+   import sys
+   fuse = FUSE(Memory(), sys.argv[1], foreground=True, debug=True)

--- a/mem.py
+++ b/mem.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from collections import defaultdict
 from errno import ENOENT
 from stat import S_IFDIR, S_IFLNK, S_IFREG
@@ -7,11 +5,11 @@ from sys import argv, exit
 from time import time
 from fuse import FUSE, FuseOSError, Operations, LoggingMixIn
 
+
 class Property(dict):
     """ Default Properties of a file/directory object"""
 
-
-    def __init__(self, st_mode = 493, st_nlink = 0, st_size = 0, st_ctime = '', st_mtime = '', st_atime = '', st_gid = 0, st_uid = 0):
+    def __init__(self, st_mode=493, st_nlink=0, st_size=0, st_ctime='', st_mtime='', st_atime='', st_gid=0, st_uid=0):
         self.st_mode = st_mode
         self.st_nlink = st_nlink
         self.st_size = st_size
@@ -20,8 +18,6 @@ class Property(dict):
         self.st_atime = st_atime
         self.st_gid = st_gid
         self.st_uid = st_uid
-
-
 
 
 class Directory(object):
@@ -37,12 +33,10 @@ class Directory(object):
         self.properties = properties
 
 
-
-
 class File(object):
     """ A file object"""
 
-    data = ''
+    data = b''
     properties = Property()
 
     def __init__(self, data, properties):
@@ -50,24 +44,18 @@ class File(object):
         self.properties = properties
 
 
-
-
 class Memory(LoggingMixIn, Operations):
     """Example memory filesystem. Supports only one level of files."""
 
-
     def __unicode__(self):
-        return unicode(self)
-
-
+        return str(self)
 
     def __init__(self):
         self.filesystem = {}
         self.fd = 0
         now = time()
-        self.filesystem['/'] = Directory(files={}, directories={}, properties=Property(st_mode=S_IFDIR | 493, st_nlink=2, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time(), st_gid=0, st_uid=0))
-
-
+        self.filesystem['/'] = Directory(files={}, directories={}, properties=Property(
+            st_mode=S_IFDIR | 493, st_nlink=2, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time(), st_gid=0, st_uid=0))
 
     def chmod(self, path, mode):
         item = self.getFile(path)
@@ -78,8 +66,6 @@ class Memory(LoggingMixIn, Operations):
             item.properties.st_mode |= mode
         return 0
 
-
-
     def chown(self, path, uid, gid):
         item = self.getFile(path)
         if not item:
@@ -89,19 +75,16 @@ class Memory(LoggingMixIn, Operations):
             item.properties.st_gid = gid
         return 0
 
-
-
     def create(self, path, mode):
         filename = path.split('/')[-1]
         dirname = '/'.join(path.split('/')[:-1])
         dirobj = self.getDir(dirname)
-        dirobj.files[filename] = File(data='', properties=Property(st_mode=S_IFREG | mode, st_nlink=1, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time()))
+        dirobj.files[filename] = File(data=b'', properties=Property(
+            st_mode=S_IFREG | mode, st_nlink=1, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time()))
         self.fd += 1
         return self.fd
 
-
-
-    def getattr(self, path, fh = None):
+    def getattr(self, path, fh=None):
         st = self.getFile(path)
         if not st:
             st = self.getDir(path)
@@ -109,9 +92,7 @@ class Memory(LoggingMixIn, Operations):
             raise FuseOSError(ENOENT)
         return st.properties.__dict__
 
-
-
-    def getxattr(self, path, name, position = 0):
+    def getxattr(self, path, name, position=0):
         st = self.getFile(path)
         if not st:
             st = self.getDir(path)
@@ -121,50 +102,37 @@ class Memory(LoggingMixIn, Operations):
         except KeyError:
             return ''
 
-
-
     def listxattr(self, path):
         st = self.getFile(path)
         if not st:
             st = self.getDir(path)
         attrs = st.properties.get('attrs', {})
-        return attrs.keys()
-
-
+        return list(attrs.keys())
 
     def mkdir(self, path, mode):
         path = path.rstrip('/')
         newdir = path.split('/')[-1]
         dirname = '/'.join(path.split('/')[:-1])
         dirobj = self.getDir(dirname)
-        dirobj.directories[newdir] = Directory(files={}, directories={}, properties=Property(st_mode=S_IFDIR | mode, st_nlink=2, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time()))
+        dirobj.directories[newdir] = Directory(files={}, directories={}, properties=Property(
+            st_mode=S_IFDIR | mode, st_nlink=2, st_size=0, st_ctime=time(), st_mtime=time(), st_atime=time()))
         dirobj.properties.st_nlink += 1
-
-
 
     def open(self, path, flags):
         self.fd += 1
         return self.fd
 
-
-
     def read(self, path, size, offset, fh):
         fileobj = self.getFile(path)
         return fileobj.data[offset:(offset + size)]
 
-
-
     def readdir(self, path, fh):
         st = self.getDir(path)
-        return ['.', '..'] + [ x for x in st.files ] + [ x for x in st.directories ]
-
-
+        return ['.', '..'] + [x for x in st.files] + [x for x in st.directories]
 
     def readlink(self, path):
         st = self.getFile(path)
         return st.data
-
-
 
     def removexattr(self, path, name):
         st = self.getFile(path)
@@ -176,8 +144,6 @@ class Memory(LoggingMixIn, Operations):
         except KeyError:
             pass
 
-
-
     def rename(self, old, new):
         oldname = old.split('/')[-1]
         newname = new.split('/')[-1]
@@ -188,8 +154,6 @@ class Memory(LoggingMixIn, Operations):
         elif self.getDir(old):
             parentobj.directories[newname] = parentobj.directories.pop(oldname)
 
-
-
     def rmdir(self, path):
         parentname = '/'.join(path.split('/')[:-1])
         parentobj = self.getDir(parentname)
@@ -197,37 +161,28 @@ class Memory(LoggingMixIn, Operations):
         parentobj.directories.pop(dirname)
         parentobj.properties.st_nlink -= 1
 
-
-
-    def setxattr(self, path, name, value, options, position = 0):
+    def setxattr(self, path, name, value, options, position=0):
         st = self.getFile(path)
         if not st:
             st = self.getDir(path)
         attrs = st.setdefault('attrs', {})
         attrs[name] = value
 
-
-
     def statfs(self, path):
         return dict(f_bsize=512, f_blocks=4096, f_bavail=2048)
-
-
 
     def symlink(self, target, source):
         targetname = target.split('/')[-1]
         targetdir = '/'.join(target.split('/')[:-1])
         targetdirobj = self.getDir(targetdir)
 
-        targetdirobj.files[targetname] = File(data=source, properties=Property(st_mode=S_IFLNK, st_nlink=1, st_size=len(source), st_ctime=time(), st_mtime=time(), st_atime=time()))
+        targetdirobj.files[targetname] = File(data=source, properties=Property(
+            st_mode=S_IFLNK, st_nlink=1, st_size=len(source), st_ctime=time(), st_mtime=time(), st_atime=time()))
 
-
-
-    def truncate(self, path, length, fh = None):
+    def truncate(self, path, length, fh=None):
         st = self.getFile(path)
         st.data = st.data[:length]
         st.properties.st_size = length
-
-
 
     def unlink(self, path):
         dirname = '/'.join(path.split('/')[:-1])
@@ -235,24 +190,18 @@ class Memory(LoggingMixIn, Operations):
         st = self.getDir(dirname)
         st.files.pop(filename)
 
-
-
-    def utimens(self, path, times = None):
+    def utimens(self, path, times=None):
         now = time()
         (atime, mtime,) = times if times else (now, now)
         st = self.getFile(path)
         st.properties.st_atime = atime
         st.properties.st_mtime = mtime
 
-
-
     def write(self, path, data, offset, fh):
         st = self.getFile(path)
         st.data = st.data[:offset] + data
         st.properties.st_size = len(st.data)
         return len(data)
-
-
 
     def getFile(self, path):
         if path[-1] == '/':
@@ -265,8 +214,6 @@ class Memory(LoggingMixIn, Operations):
             if location and filename in location.files:
                 return location.files[filename]
             return None
-
-
 
     def getDir(self, path):
         path = path.rstrip('/')
@@ -285,10 +232,5 @@ class Memory(LoggingMixIn, Operations):
         return location
 
 
-
 if __name__ == '__main__':
-    if len(argv) != 2:
-        print 'usage: %s <mountpoint>' % argv[0]
-        exit(1)
-    fuse = FUSE(Memory(), argv[1], foreground=True, debug=True, allow_other=True)
-
+    fuse = FUSE(Memory(), argv[1], foreground=True)#, debug=True)


### PR DESCRIPTION
closes #1 

adds `python3` support, removes `python2` support.
use `bytearray` instead of `bytes` for performance improvement
populates `uid`/`gid` from running user
populates `st_blocks` for `du`